### PR TITLE
suggestion: use longer variable names

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,11 +54,13 @@ func getHostname() string {
 }
 
 func getCollectdInterval() float64 {
-	coIn := os.Getenv("COLLECTD_INTERVAL")
-	if coIn == "" {
-		coIn = "10"
+	intervalFromEnv := os.Getenv("COLLECTD_INTERVAL")
+
+	if intervalFromEnv == "" {
+		intervalFromEnv = "10"
 	}
-	collectdInterval, err := strconv.ParseFloat(coIn, 64)
+
+	collectdInterval, err := strconv.ParseFloat(intervalFromEnv, 64)
 	errCheckFatal(err)
 	return collectdInterval
 }

--- a/redisInstance.go
+++ b/redisInstance.go
@@ -49,10 +49,10 @@ func parseArgToInstance(connStr string) redisInstance {
 	}
 }
 
-func (reIn redisInstance) fetchInfo() (string, error) {
+func (instance redisInstance) fetchInfo() (string, error) {
 	client := redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", reIn.host, reIn.port),
-		Password: reIn.pw,
+		Addr:     fmt.Sprintf("%s:%d", instance.host, instance.port),
+		Password: instance.pw,
 	})
 	output, err := client.Info().Result()
 	return output, err


### PR DESCRIPTION
```
$ go test -v
=== RUN   Test_getCollectdIntervalDefault
--- PASS: Test_getCollectdIntervalDefault (0.00s)
=== RUN   Test_getCollectdIntervalAlteredEnv
--- PASS: Test_getCollectdIntervalAlteredEnv (0.00s)
=== RUN   Test_validateConnectionString
=== RUN   Test_validateConnectionString/localhost
=== RUN   Test_validateConnectionString/remotehost
=== RUN   Test_validateConnectionString/iphost
=== RUN   Test_validateConnectionString/hostWithPassword
=== RUN   Test_validateConnectionString/missing_field
=== RUN   Test_validateConnectionString/invalidPort
--- PASS: Test_validateConnectionString (0.00s)
    --- PASS: Test_validateConnectionString/localhost (0.00s)
    --- PASS: Test_validateConnectionString/remotehost (0.00s)
    --- PASS: Test_validateConnectionString/iphost (0.00s)
    --- PASS: Test_validateConnectionString/hostWithPassword (0.00s)
    --- PASS: Test_validateConnectionString/missing_field (0.00s)
    --- PASS: Test_validateConnectionString/invalidPort (0.00s)
=== RUN   Test_parseArgToInstance
=== RUN   Test_parseArgToInstance/localhost
=== RUN   Test_parseArgToInstance/hostWithPassword
--- PASS: Test_parseArgToInstance (0.00s)
    --- PASS: Test_parseArgToInstance/localhost (0.00s)
    --- PASS: Test_parseArgToInstance/hostWithPassword (0.00s)
=== RUN   Test_fetchMetricValue
=== RUN   Test_fetchMetricValue/fetch_total_net_input_bytes
=== RUN   Test_fetchMetricValue/fetch_allocator_frag_bytes
--- PASS: Test_fetchMetricValue (0.00s)
    --- PASS: Test_fetchMetricValue/fetch_total_net_input_bytes (0.00s)
    --- PASS: Test_fetchMetricValue/fetch_allocator_frag_bytes (0.00s)
=== RUN   Test_generateRecordsMetrics
--- PASS: Test_generateRecordsMetrics (0.00s)
=== RUN   Test_generateUniqueMetrics
--- PASS: Test_generateUniqueMetrics (0.00s)
=== RUN   Test_parsePutvalString
=== RUN   Test_parsePutvalString/Put_CPU_metric
=== RUN   Test_parsePutvalString/Put_Connection_Metric
--- PASS: Test_parsePutvalString (0.00s)
    --- PASS: Test_parsePutvalString/Put_CPU_metric (0.00s)
    --- PASS: Test_parsePutvalString/Put_Connection_Metric (0.00s)
PASS
ok  	github.com/gricertg/collectd-redis	0.003s
```