### PR TITLE
fix redis connection leaking by creating the connection outside the loop

### DIFF
--- a/redisInstance.go
+++ b/redisInstance.go
@@ -49,11 +49,7 @@ func parseArgToInstance(connStr string) redisInstance {
 	}
 }
 
-func (instance redisInstance) fetchInfo() (string, error) {
-	client := redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", instance.host, instance.port),
-		Password: instance.pw,
-	})
+func fetchRedisInfo(client *redis.Client) (string, error) {
 	output, err := client.Info().Result()
 	return output, err
 }


### PR DESCRIPTION
The connection for fetching the redis information is created within a function which runs in the main loop of the plugin. Because the connection is never closed many redis client connections are established for fetching the info. 

The most efficient way is to create the client outside of the loop. 